### PR TITLE
Fix IOS captureFrame and add support for remote stream captureFrame

### DIFF
--- a/common/darwin/Classes/FlutterRTCFrameCapturer.h
+++ b/common/darwin/Classes/FlutterRTCFrameCapturer.h
@@ -9,4 +9,6 @@
 
 - (instancetype)initWithTrack:(RTCVideoTrack *) track toPath:(NSString *) path result:(FlutterResult)result;
 
++ (UIImage *)convertFrameToUIImage:(RTCVideoFrame *)frame;
+
 @end

--- a/common/darwin/Classes/FlutterRTCFrameCapturer.m
+++ b/common/darwin/Classes/FlutterRTCFrameCapturer.m
@@ -9,6 +9,8 @@
 
 #include "libyuv.h"
 
+#define clamp(a) (a>255?255:(a<0?0:a))
+
 @import CoreImage;
 @import CoreVideo;
 
@@ -36,37 +38,65 @@
 {
 }
 
+// Thanks Juan Giorello https://groups.google.com/g/discuss-webrtc/c/ULGIodbbLvM
++ (UIImage *)convertFrameToUIImage:(RTCVideoFrame *)frame {
+    // https://chromium.googlesource.com/external/webrtc/+/refs/heads/main/sdk/objc/base/RTCVideoFrame.h    
+    // RTCVideoFrameBuffer *rtcFrameBuffer = (RTCVideoFrameBuffer *)frame.buffer;
+    // RTCI420Buffer *buffer = [rtcFrameBuffer toI420];
+
+    // https://chromium.googlesource.com/external/webrtc/+/refs/heads/main/sdk/objc/base/RTCVideoFrameBuffer.h
+    // This guarantees the buffer will be RTCI420Buffer
+    RTCI420Buffer *buffer = [frame.buffer toI420];
+    
+    
+    int width = buffer.width;
+    int height = buffer.height;
+    int bytesPerPixel = 4;
+    uint8_t *rgbBuffer = malloc(width * height * bytesPerPixel);
+    
+    for(int row = 0; row < height; row++) {
+        const uint8_t *yLine = &buffer.dataY[row * buffer.strideY];
+        const uint8_t *uLine = &buffer.dataU[(row >> 1) * buffer.strideU];
+        const uint8_t *vLine = &buffer.dataV[(row >> 1) * buffer.strideV];
+        
+        for(int x = 0; x < width; x++) {
+            int16_t y = yLine[x];
+            int16_t u = uLine[x >> 1] - 128;
+            int16_t v = vLine[x >> 1] - 128;
+            
+            int16_t r = roundf(y + v * 1.4);
+            int16_t g = roundf(y + u * -0.343 + v * -0.711);
+            int16_t b = roundf(y + u * 1.765);
+            
+            uint8_t *rgb = &rgbBuffer[(row * width + x) * bytesPerPixel];
+            rgb[0] = 0xff;
+            rgb[1] = clamp(b);
+            rgb[2] = clamp(g);
+            rgb[3] = clamp(r);
+        }
+    }
+    
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef context = CGBitmapContextCreate(rgbBuffer, width, height, 8, width * bytesPerPixel, colorSpace, kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipLast);
+    
+    CGImageRef cgImage = CGBitmapContextCreateImage(context);
+    CGContextRelease(context);
+    CGColorSpaceRelease(colorSpace);
+    free(rgbBuffer);
+    
+    UIImage *image = [UIImage imageWithCGImage:cgImage];
+    CGImageRelease(cgImage);
+    
+    return image;
+}
+
 - (void)renderFrame:(nullable RTCVideoFrame *)frame
 {
 #if TARGET_OS_IPHONE
     if (_gotFrame || frame == nil) return;
     _gotFrame = true;
 
-    id<RTCVideoFrameBuffer> buffer = frame.buffer;
-    CVPixelBufferRef pixelBufferRef = ((RTCCVPixelBuffer *) buffer).pixelBuffer;
-
-    CIImage *ciImage = [CIImage imageWithCVPixelBuffer:pixelBufferRef];
-    CIContext *context = [CIContext contextWithOptions:nil];
-    CGImageRef cgImage = [context createCGImage:ciImage
-                                       fromRect:CGRectMake(0, 0, frame.width, frame.height)];
-
-    UIImageOrientation orientation;
-    switch (frame.rotation) {
-        case RTCVideoRotation_90:
-            orientation = UIImageOrientationRight;
-            break;
-        case RTCVideoRotation_180:
-            orientation = UIImageOrientationDown;
-            break;
-        case RTCVideoRotation_270:
-            orientation = UIImageOrientationLeft;
-        default:
-            orientation = UIImageOrientationUp;
-            break;
-    }
-
-    UIImage *uiImage = [UIImage imageWithCGImage:cgImage scale:1 orientation:orientation];
-    CGImageRelease(cgImage);
+    UIImage *uiImage = [FlutterRTCFrameCapturer convertFrameToUIImage:frame];
     NSData *jpgData = UIImageJPEGRepresentation(uiImage, 0.9f);
 
     if ([jpgData writeToFile:_path atomically:NO]) {

--- a/common/darwin/Classes/FlutterRTCFrameCapturer.m
+++ b/common/darwin/Classes/FlutterRTCFrameCapturer.m
@@ -9,6 +9,8 @@
 
 #include "libyuv.h"
 
+#define clamp(a) (a>255?255:(a<0?0:a))
+
 @import CoreImage;
 @import CoreVideo;
 
@@ -36,36 +38,65 @@
 {
 }
 
+// Thanks Juan Giorello https://groups.google.com/g/discuss-webrtc/c/ULGIodbbLvM
++ (UIImage *)convertFrameToUIImage:(RTCVideoFrame *)frame {
+    // https://chromium.googlesource.com/external/webrtc/+/refs/heads/main/sdk/objc/base/RTCVideoFrame.h    
+    // RTCVideoFrameBuffer *rtcFrameBuffer = (RTCVideoFrameBuffer *)frame.buffer;
+    // RTCI420Buffer *buffer = [rtcFrameBuffer toI420];
+
+    // https://chromium.googlesource.com/external/webrtc/+/refs/heads/main/sdk/objc/base/RTCVideoFrameBuffer.h
+    // This guarantees the buffer will be RTCI420Buffer
+    RTCI420Buffer *buffer = [frame.buffer toI420];
+    
+    
+    int width = buffer.width;
+    int height = buffer.height;
+    int bytesPerPixel = 4;
+    uint8_t *rgbBuffer = malloc(width * height * bytesPerPixel);
+    
+    for(int row = 0; row < height; row++) {
+        const uint8_t *yLine = &buffer.dataY[row * buffer.strideY];
+        const uint8_t *uLine = &buffer.dataU[(row >> 1) * buffer.strideU];
+        const uint8_t *vLine = &buffer.dataV[(row >> 1) * buffer.strideV];
+        
+        for(int x = 0; x < width; x++) {
+            int16_t y = yLine[x];
+            int16_t u = uLine[x >> 1] - 128;
+            int16_t v = vLine[x >> 1] - 128;
+            
+            int16_t r = roundf(y + v * 1.4);
+            int16_t g = roundf(y + u * -0.343 + v * -0.711);
+            int16_t b = roundf(y + u * 1.765);
+            
+            uint8_t *rgb = &rgbBuffer[(row * width + x) * bytesPerPixel];
+            rgb[0] = 0xff;
+            rgb[1] = clamp(b);
+            rgb[2] = clamp(g);
+            rgb[3] = clamp(r);
+        }
+    }
+    
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef context = CGBitmapContextCreate(rgbBuffer, width, height, 8, width * bytesPerPixel, colorSpace, kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipLast);
+    
+    CGImageRef cgImage = CGBitmapContextCreateImage(context);
+    CGContextRelease(context);
+    CGColorSpaceRelease(colorSpace);
+    free(rgbBuffer);
+    
+    UIImage *image = [UIImage imageWithCGImage:cgImage];
+    CGImageRelease(cgImage);
+    
+    return image;
+}
+
 - (void)renderFrame:(nullable RTCVideoFrame *)frame
 {
 #if TARGET_OS_IPHONE
     if (_gotFrame || frame == nil) return;
     _gotFrame = true;
 
-    id<RTCVideoFrameBuffer> buffer = frame.buffer;
-    CVPixelBufferRef pixelBufferRef = ((RTCCVPixelBuffer *) buffer).pixelBuffer;
-
-    CIImage *ciImage = [CIImage imageWithCVPixelBuffer:pixelBufferRef];
-    CIContext *context = [CIContext contextWithOptions:nil];
-    CGImageRef cgImage = [context createCGImage:ciImage
-                                       fromRect:CGRectMake(0, 0, frame.width, frame.height)];
-
-    UIImageOrientation orientation;
-    switch (frame.rotation) {
-        case RTCVideoRotation_90:
-            orientation = UIImageOrientationRight;
-            break;
-        case RTCVideoRotation_180:
-            orientation = UIImageOrientationDown;
-            break;
-        case RTCVideoRotation_270:
-            orientation = UIImageOrientationLeft;
-        default:
-            orientation = UIImageOrientationUp;
-            break;
-    }
-
-    UIImage *uiImage = [UIImage imageWithCGImage:cgImage scale:1 orientation:orientation];
+    UIImage *uiImage = [FlutterRTCFrameCapturer convertFrameToUIImage:frame];
     CGImageRelease(cgImage);
     NSData *jpgData = UIImageJPEGRepresentation(uiImage, 0.9f);
 

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -593,11 +593,6 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
 
 -(void)mediaStreamTrackCaptureFrame:(RTCVideoTrack *)track toPath:(NSString *) path result:(FlutterResult)result
 {
-    if (!self.videoCapturer) {
-        NSLog(@"Video capturer is null. Can't capture frame.");
-        return;
-    }
-
     self.frameCapturer = [[FlutterRTCFrameCapturer alloc] initWithTrack:track toPath:path result:result];
 }
 


### PR DESCRIPTION
This pull request fixes the screen capture feature on IOS.

Additionally, IOS now supports screen captures for remote streams; this was previously not possible.

Changes are based on discussion here https://groups.google.com/g/discuss-webrtc/c/ULGIodbbLvM.

Fixes issues #765 and #635.

The previous code was using a deprecated (now removed) API of the WebRTC-SDK.